### PR TITLE
Fix missing advantage computation when reward_EMA is disabled

### DIFF
--- a/models.py
+++ b/models.py
@@ -409,6 +409,8 @@ class ImagBehavior(nn.Module):
             metrics.update(tools.tensorstats(normed_target, "normed_target"))
             metrics["EMA_005"] = to_np(self.ema_vals[0])
             metrics["EMA_095"] = to_np(self.ema_vals[1])
+        else:
+            adv = target - base
 
         if self._config.imag_gradient == "dynamics":
             actor_target = adv


### PR DESCRIPTION
Fix an issue where reward_EMA=False caused adv to be undefined in _compute_actor_loss.

Previously, adv was only computed inside the reward_EMA branch, which resulted in a runtime error when the option was disabled.